### PR TITLE
add a warning message when file does not exist

### DIFF
--- a/rock.c
+++ b/rock.c
@@ -1430,7 +1430,10 @@ int rock_flash_read_lba_to_file_progress(struct xrock_ctx_t * ctx, uint32_t sec,
 
 	FILE * f = fopen(filename, "w");
 	if(!f)
-		return 0;
+	{
+		perror("Failed to open file for writing");
+		exit(-1);
+	}
 
 	if(cnt <= 65536)
 		MAXSEC = 128;
@@ -1481,7 +1484,10 @@ int rock_flash_write_lba_from_file_progress(struct xrock_ctx_t * ctx, uint32_t s
 
 	FILE * f = fopen(filename, "r");
 	if(!f)
-		return 0;
+	{
+		perror("Failed to read file");
+		exit(-1);
+	}
 
 	fseek(f, 0, SEEK_END);
 	int64_t len = ftell(f);


### PR DESCRIPTION
add a warning message when flash write/read file does not exist or other Failed
before:
<img width="735" height="36" alt="图片" src="https://github.com/user-attachments/assets/d61248e8-adb6-4378-8c71-a4ad66bb46e0" />

after:
<img width="735" height="36" alt="图片" src="https://github.com/user-attachments/assets/f82436ae-b8a0-46d6-8ff0-3c134577635c" />
